### PR TITLE
Add pagination to loan requests index

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -23,6 +23,7 @@ gem "traceroute"
 gem "rails_12factor", group: :production
 gem "populator"
 gem "newrelic_rpm"
+gem "will_paginate"
 
 group :development, :test do
   gem "pry-rails"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -239,6 +239,7 @@ GEM
     websocket-driver (0.6.2)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.2)
+    will_paginate (3.0.7)
     xpath (2.0.0)
       nokogiri (~> 1.3)
 
@@ -281,6 +282,7 @@ DEPENDENCIES
   twitter-bootstrap-rails
   uglifier (>= 1.3.0)
   web-console (~> 2.0)
+  will_paginate
 
 BUNDLED WITH
    1.10.6

--- a/app/controllers/loan_requests_controller.rb
+++ b/app/controllers/loan_requests_controller.rb
@@ -2,7 +2,7 @@ class LoanRequestsController < ApplicationController
   before_action :set_loan_request, only: [:update, :show]
 
   def index
-    @loan_requests = LoanRequest.all
+    @loan_requests = LoanRequest.paginate(page: params[:page])
   end
 
   def create

--- a/app/views/loan_requests/index.html.erb
+++ b/app/views/loan_requests/index.html.erb
@@ -21,3 +21,5 @@
 <br>
 
 <%= render "shared/lender_thumbnail" %>
+
+<%= will_paginate @loan_requests %>


### PR DESCRIPTION
Add pagination to main loan requests index so page can be loaded and further performance analysis can be done.
