### PR TITLE
Use includes to fix n+1 query on lenders show page

### DIFF
--- a/app/controllers/lenders_controller.rb
+++ b/app/controllers/lenders_controller.rb
@@ -20,6 +20,8 @@ class LendersController < ApplicationController
   end
 
   def show
+    @projects = @lender.projects.includes(:user)
+
     unless current_lender?
       redirect_to root_path, notice: "Access denied"
     end

--- a/app/views/lenders/show.html.erb
+++ b/app/views/lenders/show.html.erb
@@ -22,7 +22,7 @@
         </tr>
       </thead>
       <tbody>
-        <% @lender.projects.each do |project| %>
+        <% @projects.each do |project| %>
       <tr>
         <td class="text-center"><%= @lender.contributed_to(project).newest_contribution %></td>
         <td class="text-center"><%= project.title %></td>


### PR DESCRIPTION
Fix lenders show page so it no longer makes additional calls to pull user (borrower) data in projects (loan requests)
