### PR TITLE
Add/fix loan request categories feature

### DIFF
--- a/app/controllers/borrowers_controller.rb
+++ b/app/controllers/borrowers_controller.rb
@@ -19,6 +19,7 @@ class BorrowersController < ApplicationController
 
   def show
     @loan_requests = LoanRequest.where(user_id: params[:id])
+    @categories = Category.pluck(:title, :id)
   end
 
   private

--- a/app/views/borrowers/_new_loan_request.html.erb
+++ b/app/views/borrowers/_new_loan_request.html.erb
@@ -10,7 +10,7 @@
     <%= f.date_field :requested_by_date %>
     <%= f.date_field :repayment_begin_date %>
     <%= f.select :repayment_rate, [["Monthly", "monthly"], ["Weekly", "weekly"]], {}, { class: "selectpicker" } %>
-    <%= f.select :category, [["Agriculture", "agriculture"], ["Community", "community"], ["Education", "education"]], { prompt: "Select category" }, { class: "selectpicker" } %>
+    <%= f.select :category, @categories, { prompt: "Select category" }, { class: "selectpicker" } %>
     <%= f.text_field :amount, prepend: "$", append: ".00" %>
   <div class="modal-footer">
     <%= f.submit "Submit" %>

--- a/app/views/loan_requests/_category_filter.js.erb
+++ b/app/views/loan_requests/_category_filter.js.erb
@@ -1,0 +1,14 @@
+<script>
+  $("#category").change(function() {
+    var $category = $(this).val();
+
+    $.ajax({
+      type:    "GET",
+      url:     "/browse",
+      data:    " category: " + $category,
+      success: function(data) {
+        document.location.href = "browse?category=" + $category
+      }
+    });
+  });
+</script>

--- a/app/views/loan_requests/_form.html.erb
+++ b/app/views/loan_requests/_form.html.erb
@@ -8,7 +8,7 @@
   <%= f.date_field :requested_by_date %>
   <%= f.date_field :repayment_begin_date %>
   <%= f.select :repayment_rate, [["Monthly", "monthly"], ["Weekly", "weekly"]], {}, { class: "selectpicker" } %>
-  <%= f.select :categories, [["Agriculture", "agriculture"], ["Community", "community"], ["Education", "education"]], {label: "Category"}, { class: "selectpicker" } %>
+  <%= f.select :categories, @categories, { prompt: "Select category" }, { class: "selectpicker" } %>
   <%= f.text_field :amount, prepend: "$", append: ".00" %>
   <div class="modal-footer">
     <%= f.submit :submit, id: "submit-button", onclick: "hideModal()" %>

--- a/app/views/loan_requests/index.html.erb
+++ b/app/views/loan_requests/index.html.erb
@@ -5,11 +5,12 @@
 <div class="container">
   <div class="row">
     <div class="col-md-3 pull-left">
-      <select class="form-control btn-info">
-        <option value="farming">Farming</option>
-        <option value="education">Education</option>
-        <option value="medical">Medical</option>
-        <option value="repair">Women</option>
+      <select id="category" class="form-control btn-info">
+        <option value="">All Categories</option>
+        <% @categories.each do |category| %>
+          <% selected = (@category && @category.to_i == category.id) ? "selected" : nil %>
+          <option value="<%= category.id %>" <%= selected %>><%= category.title %></option>
+        <% end %>
       </select>
     </div>
 
@@ -23,3 +24,6 @@
 <%= render "shared/lender_thumbnail" %>
 
 <%= will_paginate @loan_requests %>
+
+<%= render "category_filter.js" %>
+      .loan_requests << loan_request


### PR DESCRIPTION
Categories feature was never implemented correctly in the original app.
Users can now view, create, and edit loan requests by all categories.
Category dropdowns are now dynamically populated from the database.
